### PR TITLE
fix: Add additional headroom configurability

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -41,8 +41,9 @@ resource "spotinst_ocean_aws" "this" {
   }
 
   autoscaler {
-    autoscale_is_enabled     = true
-    autoscale_is_auto_config = true
+    autoscale_is_enabled                 = var.autoscale_is_enabled
+    autoscale_is_auto_config             = var.autoscale_is_auto_config
+    enable_automatic_and_manual_headroom = var.enable_automatic_and_manual_headroom
   }
 
   update_policy {

--- a/variables.tf
+++ b/variables.tf
@@ -228,3 +228,21 @@ variable "update_policy_batch_size_percentage" {
   default     = 25
   description = "When rolling the cluster due to an update, the percentage of the instances to deploy in each batch."
 }
+
+variable "autoscale_is_enabled" {
+  type        = bool
+  description = "Enable the Ocean Kubernetes Auto Scaler."
+  default     = true
+}
+
+variable "autoscale_is_auto_config" {
+  type        = bool
+  description = "Automatically configure and optimize headroom resources."
+  default     = true
+}
+
+variable "enable_automatic_and_manual_headroom" {
+  type        = bool
+  description = "Enables automatic and manual headroom to work in parallel. When set to false, automatic headroom overrides all other headroom definitions manually configured, whether they are at cluster or VNG level."
+  default     = true
+}


### PR DESCRIPTION
## what
* Allow both manual and automatic headroom to coexist
* Make all 3 headroom options configurable

## why
* Automatic headroom doesn't work for us because Spot support claims that our existing resource requests "were too small for automatic headroom calculation" (they have yet to tell me how big these requests would need to be for the feature to work), so I have setup manual headroom at the VNG level, which does work as expected

