### PR TITLE
feat: adds ability to set graceful node shutdown kubelet configurations

### DIFF
--- a/.spacelift/config.yml
+++ b/.spacelift/config.yml
@@ -1,2 +1,2 @@
 version: 1
-module_version: 0.0.1
+module_version: 0.1.0

--- a/userdata.tf
+++ b/userdata.tf
@@ -34,6 +34,8 @@ locals {
     kubelet_extra_args              = local.kubelet_extra_args
     bootstrap_extra_args            = var.bootstrap_additional_options == null ? "" : var.bootstrap_additional_options
     after_cluster_joining_userdata  = var.after_cluster_joining_userdata == null ? "" : var.after_cluster_joining_userdata
+    shutdownGracePeriod             = var.kubelet_graceful_node_shutdown.shutdownGracePeriod
+    shutdownGracePeriodCriticalPods = var.kubelet_graceful_node_shutdown.shutdownGracePeriodCriticalPods
   }
 
   cluster_data = {

--- a/userdata.tpl
+++ b/userdata.tpl
@@ -1,7 +1,13 @@
 #!/bin/bash
 ${before_cluster_joining_userdata}
+
 %{ if length(kubelet_extra_args) > 0 }
 export KUBELET_EXTRA_ARGS="${kubelet_extra_args}"
 %{ endif }
+
+KUBELET_CONFIG=/etc/kubernetes/kubelet/kubelet-config.json
+echo "$(jq ".shutdownGracePeriod=\"${shutdownGracePeriod}\"" $KUBELET_CONFIG)" > $KUBELET_CONFIG
+echo "$(jq ".shutdownGracePeriodCriticalPods=\"${shutdownGracePeriodCriticalPods}\"" $KUBELET_CONFIG)" > $KUBELET_CONFIG
+
 /etc/eks/bootstrap.sh --apiserver-endpoint '${cluster_endpoint}' --b64-cluster-ca '${certificate_authority_data}' ${bootstrap_extra_args} '${cluster_name}'
 ${after_cluster_joining_userdata}

--- a/variables.tf
+++ b/variables.tf
@@ -254,7 +254,7 @@ variable "kubelet_graceful_node_shutdown" {
   })
   default = {
     shutdownGracePeriod             = "60s"
-    shutdownGracePeriodCriticalPods = "45s"
+    shutdownGracePeriodCriticalPods = "20s"
   }
   description = "Configures graceful node shutdown.  Set to 0 to disable graceful node shutdowns https://kubernetes.io/docs/concepts/architecture/nodes/#graceful-node-shutdown"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -246,3 +246,15 @@ variable "enable_automatic_and_manual_headroom" {
   description = "Enables automatic and manual headroom to work in parallel. When set to false, automatic headroom overrides all other headroom definitions manually configured, whether they are at cluster or VNG level."
   default     = true
 }
+
+variable "kubelet_graceful_node_shutdown" {
+  type = object({
+    shutdownGracePeriod             = string
+    shutdownGracePeriodCriticalPods = string
+  })
+  default = {
+    shutdownGracePeriod             = "60s"
+    shutdownGracePeriodCriticalPods = "45s"
+  }
+  description = "Configures graceful node shutdown.  Set to 0 to disable graceful node shutdowns https://kubernetes.io/docs/concepts/architecture/nodes/#graceful-node-shutdown"
+}


### PR DESCRIPTION
## what
* feat: adds ability to set graceful node shutdown kubelet configurations

## why
* K8s worker node shutdowns (whether due to Spot Ocean cluster rolls or otherwise) have sometimes been observered to be a potential cause critical application pods to enter crashloop back-offs when, for example, a system-critical pod such as `kube-proxy` is evicted prior to an application pod.  In this scenario, because the kube-proxy pod was terminated on the node, the application pod could no longer receive traffic from cluster-external hosts.
* Enabling graceful node shutdown configurations should help alleviate this issue with the tradeoff being increased time to shutdown a given worker node.

## references
* https://brightai.atlassian.net/browse/CORE-877
* https://kubernetes.io/docs/concepts/architecture/nodes/#graceful-node-shutdown
* https://bright-ai.slack.com/archives/C04CZPSV0H1/p1709340212508629?thread_ts=1709250794.231339&cid=C04CZPSV0H1
