### PR TITLE
fix: failed cluster roll during drift detection

### DIFF
--- a/.spacelift/config.yml
+++ b/.spacelift/config.yml
@@ -1,2 +1,2 @@
 version: 1
-module_version: 0.1.0
+module_version: 0.1.1

--- a/main.tf
+++ b/main.tf
@@ -51,6 +51,7 @@ resource "spotinst_ocean_aws" "this" {
 
     roll_config {
       batch_size_percentage = var.update_policy_batch_size_percentage
+      launch_spec_ids = var.update_policy_launch_spec_ids
     }
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -258,3 +258,9 @@ variable "kubelet_graceful_node_shutdown" {
   }
   description = "Configures graceful node shutdown.  Set to 0 to disable graceful node shutdowns https://kubernetes.io/docs/concepts/architecture/nodes/#graceful-node-shutdown"
 }
+
+variable "update_policy_launch_spec_ids" {
+  type = list(string)
+  default = null
+  description = "List of virtual node group identifiers to be rolled during update."
+}


### PR DESCRIPTION
## what

- adds `var.update_policy_launch_spec_ids`

## why

- Error received when trying to update multiple VNGs. Often during drift detection runs.
```terraform
  │ Error: onRoll() -> Roll failed for cluster [<redacted>], error: POST https://api.spotinst.io/ocean/aws/k8s/cluster/<redacted>/roll?accountId=<redacted>: 
    400 (request: "78be1b6a-e9a6-4917-90a0-e6708f6777b3") CLUSTER_ROLL_ALREADY_IN_PROGRESS: Can't have 2 Rolls at the same time. Please stop the previous one.
```
- provide the list of vng_ids in the `update_policy`

## references

- https://github.com/spotinst/terraform-provider-spotinst/issues/447
- https://registry.terraform.io/providers/spotinst/spotinst/latest/docs/resources/ocean_aws#launch_spec_ids-1
